### PR TITLE
Steam Account Management update

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,6 +21,7 @@ module.exports = {
 				csgoempireApiKey: env('CSGOEMPIRE_API_KEY', '12345678923456789234567'), // https://csgoempire.com/trading/apikey
 				csgotrader: env('CSGOTRADER', false), // set true if you using Gery's chrome extension, to autosend the offers
 				delistThreshold: env('DELIST_THRESHOLD', 5), // The percentage to delist the item if its drop in price.
+				stuckTradesPollRate: env('CSGOEMPIRE_POLL_RATE', 5), // How often to check for stuck trades. IN MINUTES
 				steam: {
 					accountName: env('STEAM_ACCOUNT_NAME', false), // Your Steam username (not necessary), set false to disable steam
 					password: env('STEAM_PASSWORD', 'aaaaaaaaaaaaaa'), // Your Steam password (not necessary)

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
 		"socket.io-client": "2.0.3",
 		"steam-totp": "^2.1.2",
 		"steam-tradeoffer-manager": "^2.10.5",
+		"steam-user": "^4.28.1",
 		"steamcommunity": "^3.44.3",
 		"ts-node": "^9.1.1"
 	},
 	"devDependencies": {
 		"@types/node": "^18.11.10",
 		"tslint": "^5.12.1",
-		"typescript": "^4.4" 
+		"typescript": "^4.4"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@
 -   [@Artemis]( https://github.com/Art-em1s )
 -   [@Pixel]( https://github.com/PixelBoii )
 -   [@Tavin]( https://github.com/tavindev )
+-   [@Sampli]( https://github.com/easton36 )
 
 You can configure the bot as you want.
 

--- a/src/@types/config.d.ts
+++ b/src/@types/config.d.ts
@@ -17,6 +17,7 @@ interface Csgoempire {
 	origin: string;
 	delistThreshold: number;
 	csgoempireApiKey: string;
+	stuckTradesPollRate: number;
 }
 interface Steam {
 	accountName: string;

--- a/src/@types/config.d.ts
+++ b/src/@types/config.d.ts
@@ -38,6 +38,12 @@ interface Settings {
 interface Notifications {
 	steamLoginSuccess: boolean;
 	steamLoginFailed: boolean;
+	steamWebSession: boolean;
+	steamManagerSetCookiesFailed: boolean;
+	steamManagerSetCookiesSuccess: boolean;
+	steamClientError: boolean;
+	steamDisconnected: boolean;
+	steamAccountLimitations: boolean;
 	connectEmpire: boolean;
 	p2pItemUpdatedDelist: boolean;
 	p2pItemUpdatedPriceChanged: boolean;

--- a/src/services/csgoempire.ts
+++ b/src/services/csgoempire.ts
@@ -107,6 +107,10 @@ export class CsgoempireService {
 	}
 	private initDepositPoller(userId) {
 		this.helperService.log(`Deposit Poller started for ${userId}`);
+		const config = this.helperService.config.settings.csgoempire.find(
+			(config) => config.userId === userId
+		);
+
 		this._depositPollers[`poll_${userId}`] = setInterval(async () => {
 			this.helperService.log(`Polling for ${userId} stuck deposits`);
 			const responseData = await this.getActiveTrades(userId);
@@ -117,9 +121,6 @@ export class CsgoempireService {
 				(trade) => trade.status === 3 // 3 = sending
 			);
 			this.helperService.log(`Found ${tradesToBeSent.length} stuck deposits for ${userId}`);
-			const config = this.helperService.config.settings.csgoempire.find(
-				(config) => config.userId === userId
-			);
 
 			// send the trades
 			for await(const trade of tradesToBeSent){
@@ -141,7 +142,7 @@ export class CsgoempireService {
 			}
 
 			return this.helperService.log(`Deposit Poller finished for ${userId}`);
-		}, 5 * 60 * 1000); // 5 minutes
+		}, (config.stuckTradesPollRate || 5) * (60 * 1000)); // default is 5 minutes
 	}
 	private initSocket(userId) {
 		const config = this.helperService.config.settings.csgoempire.find(

--- a/src/services/csgoempire.ts
+++ b/src/services/csgoempire.ts
@@ -159,7 +159,7 @@ export class CsgoempireService {
 			},
 		});
 		this._sockets[`user_${userId}`].on("error", (err, v) => {
-			this.helperService.log(`error: ${err}`);
+			this.helperService.log(`Websocket Error: ${err}`);
 		});
 		this._sockets[`user_${userId}`].on("connect", async () => {
 			this._sockets[`user_${userId}`].emit('filters', { 'price_max': 10 }); // set it to 10 to reduce the socket bandwidth

--- a/src/services/helper.ts
+++ b/src/services/helper.ts
@@ -14,6 +14,12 @@ export class HelperService {
 	private eventColors = {
 		steamLoginSuccess: 1,
 		steamLoginFailed: 2,
+		steamWebSession: 1,
+		steamManagerSetCookiesFailed: 2,
+		steamManagerSetCookiesSuccess: 1,
+		steamClientError: 2,
+		steamDisconnected: 2,
+		steamAccountLimitations: 1,
 		connectEmpire: 1,
 		p2pItemUpdatedDelist: 1,
 		p2pItemUpdatedPriceChanged: 1,


### PR DESCRIPTION
- Adds the `steam-user` library which is more stable for session handling
- Listens to a lot more events (from steam-user) so we can re-login
- Tells user their account limitations and bans
- I just commented out the old methods in-case they need to be easily referenced in the future
- Made stuck trades polling rate configurable (Per rannmann request in #32  )

Probably addresses issue #30 

Example:
```
[2023-04-11 14:42:16.499] Steam disconnected for ***** eresult=3 msg=NoConnection (should auto-reconnect)
[2023-04-11 14:42:23.139] Steam login success for *****
[2023-04-11 14:42:23.139] Steam account limitations for ***** limited=false communityBanned=false locked=false
[2023-04-11 14:42:23.598] Steam got web session for *****. Session ID: ###############
[2023-04-11 14:42:23.599] Steam set cookies success for *****
```